### PR TITLE
Some ideas for your cron

### DIFF
--- a/run-wp-cron-multi.sh
+++ b/run-wp-cron-multi.sh
@@ -13,7 +13,7 @@ THIS_OWNER="$(stat . -c %U)"
 wp --allow-root site list --field=url | while read SITE_URL; do
     wp --allow-root --url="$SITE_URL" cron event list --fields=hook | while read HOOK; do
         # Run as the the directory's owner
-        sudo -u "$THIS_OWNER" -- timeout 300 wp --url="$SITE_URL" cron event run "$HOOK" \
+        nice sudo -u "$THIS_OWNER" -- timeout 300 wp --url="$SITE_URL" cron event run "$HOOK" \
             || echo "${SITE} / ${HOOK} error." >&2
         # Prevent all sites from running wp-cron at once
         sleep "$DELAY"

--- a/run-wp-cron-multi.sh
+++ b/run-wp-cron-multi.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-
+#
+# WordPress-Multisite-System-Cron
+#
 # Change this variable to be the path to your WordPress installation
-wp_path='/var/www/html/thelastcicada.com'
+WP_PATH="/var/www/html/thelastcicada.com"
+DELAY="8"
 
-cd ${wp_path}
+[ -d "$WP_PATH" ] || exit 1
+cd "$WP_PATH"
+THIS_OWNER="$(stat . -c %U)"
 
-wp site list --field=url --allow-root | while read site
-do
-        curl -L -s ${site}wp-cron.php  # -s for silent, -L to follow redirect
-        sleep 8  #Prevent all sites from running wp-cron at once
+wp --allow-root site list --field=url | while read SITE_URL; do
+    wp --allow-root --url="$SITE_URL" cron event list --fields=hook | while read HOOK; do
+        # Run as the the directory's owner
+        sudo -u "$THIS_OWNER" -- timeout 300 wp --url="$SITE_URL" cron event run "$HOOK" \
+            || echo "${SITE} / ${HOOK} error." >&2
+        # Prevent all sites from running wp-cron at once
+        sleep "$DELAY"
+    done
 done


### PR DESCRIPTION
- nice outlook
- run cron from wp-cli as the installation's owner (hopefully PHP-FPM/FCGI runs under this user)
- timeout for cron
- lowering niceness
- error handling

May or may-not work.
Just ideas.

This is my non-wpcli cron script:
https://github.com/szepeviktor/debian-server-tools/blob/master/webserver/wp-cron-cli.sh
